### PR TITLE
Fix - In case of exception raised in decoding makes thread waits fore…

### DIFF
--- a/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tidy/tool/run-clang-tidy.py
@@ -166,13 +166,17 @@ def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
     output, err = proc.communicate()
     if proc.returncode != 0:
       failed_files.append(name)
-    with lock:
-      sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
-      if len(err) > 0:
-        sys.stdout.flush()
-        sys.stderr.write(err.decode('utf-8'))
-    queue.task_done()
-
+    try:
+      with lock:
+        sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+        if len(err) > 0:
+          sys.stdout.flush()
+          sys.stderr.write(err.decode('utf-8'))
+      queue.task_done()
+    except UnicodeDecodeError as error:
+      queue.task_done()
+      with lock:
+        sys.stdout.write("UnicodeError",error)
 
 def main():
   parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '


### PR DESCRIPTION
Since each thread finishes and joins but in case header files has data which are non utf-8 which raises exception the worker thread never notifies the completion and main thread keeps waiting forever